### PR TITLE
[BUG] Initialize the DSM shared buffers when using it first time

### DIFF
--- a/src/storage/buffer/gamma_dsm.c
+++ b/src/storage/buffer/gamma_dsm.c
@@ -390,5 +390,8 @@ gamma_buffer_dsm_attach(void)
 gamma_toc *
 gamma_buffer_dsm_toc(void)
 {
+	if (dsm_toc == NULL)
+		gamma_buffer_dsm_startup();
+
 	return dsm_toc;
 }


### PR DESCRIPTION
Initialize the DSM shared buffers when using it first time