### PR TITLE
[BUG] the upper path of the indexscan need not to be vectorized

### DIFF
--- a/include/executor/gamma_indexonlyscan.h
+++ b/include/executor/gamma_indexonlyscan.h
@@ -22,6 +22,7 @@
 
 extern const CustomPathMethods* gamma_indexonlyscan_methods(void);
 extern void gamma_indexonlyscan_init(void);
+extern bool gamma_is_indexonlyscan_custompath(CustomPath *cpath);
 extern bool gamma_is_indexonlyscan_customscan(CustomScan *cscan);
 
 #endif   /* GAMMA_INDEXONLYSCAN_H */

--- a/include/executor/gamma_indexscan.h
+++ b/include/executor/gamma_indexscan.h
@@ -22,6 +22,7 @@
 
 extern const CustomPathMethods* gamma_indexscan_methods(void);
 extern void gamma_indexscan_init(void);
+extern bool gamma_is_indexscan_custompath(CustomPath *cpath);
 extern bool gamma_is_indexscan_customscan(CustomScan *cscan);
 
 #endif   /* GAMMA_INDEXSCAN_H */

--- a/src/executor/gamma_indexonlyscan.c
+++ b/src/executor/gamma_indexonlyscan.c
@@ -106,6 +106,12 @@ gamma_indexonlyscan_methods(void)
 }
 
 bool
+gamma_is_indexonlyscan_custompath(CustomPath *cpath)
+{
+	return ((void *)cpath->methods == (void *)&gamma_indexonlyscan_path_methods);
+}
+
+bool
 gamma_is_indexonlyscan_customscan(CustomScan *cscan)
 {
 	return ((void *)cscan->methods == (void *)&gamma_indexonlyscan_scan_methods);

--- a/src/executor/gamma_indexscan.c
+++ b/src/executor/gamma_indexscan.c
@@ -105,6 +105,12 @@ gamma_indexscan_methods(void)
 }
 
 bool
+gamma_is_indexscan_custompath(CustomPath *cpath)
+{
+	return ((void *)cpath->methods == (void *)&gamma_indexscan_path_methods);
+}
+
+bool
 gamma_is_indexscan_customscan(CustomScan *cscan)
 {
 	return ((void *)cscan->methods == (void *)&gamma_indexscan_scan_methods);

--- a/src/optimizer/gamma_upper_paths.c
+++ b/src/optimizer/gamma_upper_paths.c
@@ -21,6 +21,8 @@
 
 #include "executor/gamma_vec_agg.h"
 #include "executor/gamma_devectorize.h"
+#include "executor/gamma_indexscan.h"
+#include "executor/gamma_indexonlyscan.h"
 #include "executor/gamma_vec_result.h"
 #include "executor/gamma_vec_sort.h"
 #include "executor/gamma_vec_tablescan.h"
@@ -179,7 +181,14 @@ gamma_agg_path_checker(PlannerInfo *root, RelOptInfo *input_rel,
 
 	/*TODO: need compare path->parent with input_rel ? */
 	if (path->parent == input_rel && path->pathtype == T_CustomScan)
+	{
+		if (gamma_is_indexonlyscan_custompath((CustomPath *) path) ||
+			gamma_is_indexscan_custompath((CustomPath *) path))
+			return GAMMA_AGG_NO;
+
 		return GAMMA_AGG_YES;
+
+	}
 	else if (path->parent == input_rel && path->pathtype == T_SeqScan)
 		return GAMMA_AGG_NO;
 	else if (!IS_UPPER_REL(path->parent) &&


### PR DESCRIPTION
The path of the index scan operator of the gamma table merely wears the shell of a Custom Path, but in reality, it is a non-vectorized operator. Therefore, the upper-level operator of the index scan does not need to be transformed into a vectorized operator either.