### PR TITLE
[BUG] Vectorized BoolExpr

### DIFF
--- a/include/utils/vdatum/vdatum.h
+++ b/include/utils/vdatum/vdatum.h
@@ -234,5 +234,102 @@ extern vdatum *copyvdatum(vdatum *src, bool *skip);
 extern void clearvdatum(vdatum *vt);
 
 typedef struct vdatum vbool;
-vbool* buildvbool(int dim, bool *skip);
+extern vbool* buildvbool(int dim, bool *skip);
+
+static inline
+void vdatum_set_not(vdatum *datum)
+{
+	int i;
+	for(i = 0; i < datum->dim; i++)
+	{
+		datum->values[i] = BoolGetDatum(!DatumGetBool(datum->values[i]));
+	}
+
+	return;
+}
+
+static inline
+bool vdatum_check_all_null(vdatum *datum)
+{
+	int i;
+	bool result = true;
+
+	for(i = 0; i < datum->dim; i++)
+	{
+		if (!datum->isnull[i])
+		{
+			result = false;
+			break;
+		}
+	}
+
+	return result;
+}
+
+static inline
+bool vdatum_check_all_true(vdatum *datum)
+{
+	int i;
+	bool result = true;
+
+	for(i = 0; i < datum->dim; i++)
+	{
+		if (!DatumGetBool(datum->values[i]))
+		{
+			result = false;
+			break;
+		}
+	}
+
+	return result;
+}
+
+static inline
+bool vdatum_check_all_false(vdatum *datum)
+{
+	int i;
+	bool result = true;
+
+	for(i = 0; i < datum->dim; i++)
+	{
+		if (DatumGetBool(datum->values[i]))
+		{
+			result = false;
+			break;
+		}
+	}
+
+	return result;
+}
+
+static inline
+void vdatum_copy(vdatum *dst, vdatum *src)
+{
+	memcpy(dst, src, sizeof(vdatum));
+	return;
+}
+
+static inline
+void vdatum_set_and(vdatum *dst, vdatum *src)
+{
+	int i;
+	for(i = 0; i < dst->dim; i++)
+	{
+		dst->isnull[i] = dst->isnull[i] || src->isnull[i];
+		dst->values[i] = dst->values[i] & src->values[i]/* & (!dst->isnull[i])*/;
+	}
+}
+
+static inline
+void vdatum_set_or(vdatum *dst, vdatum *src)
+{
+	int i;
+	for(i = 0; i < dst->dim; i++)
+	{
+		dst->isnull[i] = dst->isnull[i] || src->isnull[i];
+		dst->values[i] = dst->values[i] | src->values[i];
+	}
+
+}
+
 #endif

--- a/src/executor/vec_exec_scan.c
+++ b/src/executor/vec_exec_scan.c
@@ -46,7 +46,7 @@ static inline TupleTableSlot* vec_tablescan_execscanfetch(ScanState *node,
 			  ExecScanAccessMtd accessMtd, ExecScanRecheckMtd recheckMtd);
 static bool tlist_matches_tupdesc(PlanState *ps, List *tlist, Index varno,
 		TupleDesc tupdesc);
-static bool vec_exec_qual(ExprState *qual, ExprContext *econtext);
+static bool gamma_exec_qual(ExprState *qual, ExprContext *econtext);
 
 /*
  * ExecScanFetch -- check interrupts & fetch next potential tuple
@@ -158,7 +158,7 @@ vec_tablescan_execscanfetch(ScanState *node,
 }
 
 static bool
-vec_exec_qual(ExprState *qual, ExprContext *econtext)
+gamma_exec_qual(ExprState *qual, ExprContext *econtext)
 {
 	int row;
 	VectorTupleSlot *vslot;
@@ -184,7 +184,6 @@ vec_exec_qual(ExprState *qual, ExprContext *econtext)
 	else if (VDATUM_IS_REF(qual_bools) && VDATUM_REF_ISNULL(qual_bools) != NULL)
 	{
 		/* do nothing */
-		//memset(vslot->skip, false, sizeof(bool) * VECTOR_SIZE);
 	}
 	else
 		memcpy(vslot->skip,VDATUM_ARR_ISNULL(qual_bools),sizeof(bool) * VECTOR_SIZE);
@@ -288,7 +287,7 @@ vec_tablescan_execscan(ScanState *node,
 		 */
 		econtext->ecxt_scantuple = slot;
 
-		if (qual == NULL || vec_exec_qual(qual, econtext))
+		if (qual == NULL || gamma_exec_qual(qual, econtext))
 		{
 			/*
 			 * Found a satisfactory scan tuple.

--- a/src/optimizer/gamma_vec_converter.c
+++ b/src/optimizer/gamma_vec_converter.c
@@ -206,38 +206,26 @@ gamma_vec_convert_mutator(Node *node, ConverterContext *ctx)
 		case T_BoolExpr:
 			{
 				BoolExpr *boolexpr = (BoolExpr*) node;
-				FuncExpr *newexpr;
-				Oid funcid = InvalidOid;
+				BoolExpr *newboolexpr;
 				List *vargs = (List *)plan_tree_mutator((Node *)boolexpr->args,
 													gamma_vec_convert_mutator,
 													ctx);
 
 				if (boolexpr->boolop == AND_EXPR)
 				{
-					funcid = gamma_get_boolexpr_and_oid();
+					newboolexpr = (BoolExpr *)makeBoolExpr(AND_EXPR, vargs, -1); 
 				}
 				else if (boolexpr->boolop == OR_EXPR)
 				{
-					funcid = gamma_get_boolexpr_or_oid();
+					newboolexpr = (BoolExpr *)makeBoolExpr(OR_EXPR, vargs, -1); 
 				}
 				else
 				{
+					newboolexpr = (BoolExpr *)makeBoolExpr(NOT_EXPR, vargs, -1); 
 					Assert(boolexpr->boolop == NOT_EXPR);
-					funcid = gamma_get_boolexpr_not_oid();
 				}
 
-				newexpr = makeNode(FuncExpr);
-				newexpr->funcid = funcid;
-				newexpr->funcresulttype = en_vec_type(BOOLOID);
-				newexpr->funcretset = false;
-				newexpr->funcvariadic = true;
-				newexpr->funcformat = COERCE_EXPLICIT_CALL; //TODO:
-				newexpr->funccollid = InvalidOid;
-				newexpr->inputcollid = InvalidOid;
-				newexpr->args = vargs;
-				newexpr->location = -1;
-
-				return (Node *)boolexpr;
+				return (Node *)newboolexpr;
 			}
 		case T_FuncExpr:
 			{


### PR DESCRIPTION
At the beginning, we implemented the and/or/not function to implement BoolExpr, so that we can better borrow the original mechanism of PostgreSQL. Currently, gamma expr has been introduced and implemented using PostgreSQL's derived expression mechanism, so a new BoolExpr implementation method is implemented.