### PR TITLE
[BUG] fix bug in Agg targetlist

### DIFF
--- a/src/executor/gamma_vec_agg.c
+++ b/src/executor/gamma_vec_agg.c
@@ -1332,13 +1332,14 @@ gamma_vec_initialize_hashentry(VecAggState *vaggstate, VecTupleHashEntry entry,
 	AggState *aggstate = vaggstate->aggstate;
 	AggStatePerHash perhash = &aggstate->perhash[aggstate->current_set];
 	TupleHashTable hashtable = perhash->hashtable;
+	TupleDesc rowdesc = vaggstate->outer_tuple_slot->tts_tupleDescriptor;
 	TupleDesc tupdesc = slot->tts_tupleDescriptor;
 
 	/* Copy the first tuple in the group and use it when projecting */
 	oldctx = MemoryContextSwitchTo(hashtable->tablecxt);
 
 	/* init first slot */
-	entry->first_slot = MakeTupleTableSlot(tupdesc, &TTSOpsVirtual);
+	entry->first_slot = MakeTupleTableSlot(rowdesc, &TTSOpsVirtual);
 
 	for (col = 0; col < tupdesc->natts; col++)
 	{


### PR DESCRIPTION
For SQL:
```
    SELECT
        ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c
    FROM hits
    GROUP BY ClientIP
    ORDER BY c DESC
    LIMIT 10;
```
IF:

- OpExpr in targetlist;
- Grouping Clause is different from targetlist; 

Then:
    **core dump.**

Because:
    The targetlist in Agg need not to vectorized except Aggref.