### PR TITLE
[OPTIMIZER] optimize grouping clause when it contains const value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ OBJS += src/optimizer/gamma_planner.o \
 		src/optimizer/gamma_join_paths.o \
 		src/optimizer/gamma_upper_paths.o \
 		src/optimizer/gamma_vec_checker.o \
-		src/optimizer/gamma_vec_converter.o
+		src/optimizer/gamma_vec_converter.o \
+		src/optimizer/gamma_rewrite_grouping_const.o
 
 #src/utils
 OBJS += src/utils/utils.o \

--- a/include/optimizer/gamma_rewrite_grouping_const.h
+++ b/include/optimizer/gamma_rewrite_grouping_const.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Gamma Data, Inc. <jackey@gammadb.com>
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GAMMA_REWRITE_GROUPING_CONST_H
+#define GAMMA_REWRITE_GROUPING_CONST_H
+
+#include "postgres.h"
+
+#include "nodes/parsenodes.h"
+#include "nodes/pathnodes.h"
+
+extern Query * gamma_rewrite_grouping_const(Query *parse);
+
+#endif /* GAMMA_REWRITE_GROUPING_CONST_H */

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -58,6 +58,8 @@ extern int					gammadb_buffers;
 extern double				gammadb_stats_analyze_tuple_factor;
 extern int					gammadb_cv_compress_method;
 
+extern bool					gammadb_rewrite_grouping_const;
+
 void _PG_init(void);
 
 static void
@@ -142,6 +144,14 @@ gamma_guc_init(void)
 							 "Copy data to cvtable directly.",
 							 NULL,
 							 &gammadb_copy_to_cvtable,
+							 true,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+	DefineCustomBoolVariable("gammadb_rewrite_grouping_const",
+							 "Remove const in Grouping Clause.",
+							 NULL,
+							 &gammadb_rewrite_grouping_const,
 							 true,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE,

--- a/src/optimizer/gamma_planner.c
+++ b/src/optimizer/gamma_planner.c
@@ -25,6 +25,7 @@
 #include "executor/vector_tuple_slot.h"
 #include "optimizer/gamma_converter.h"
 #include "optimizer/gamma_paths.h"
+#include "optimizer/gamma_rewrite_grouping_const.h"
 
 
 bool enable_gammadb = false;
@@ -63,6 +64,9 @@ gamma_vec_planner(Query	*parse,
 	PlannedStmt	*stmt;
 	List *subplans;
 	ListCell *lc;
+
+	/* rewrite */
+	parse = gamma_rewrite_grouping_const(parse);
 
 	if (planner_hook_prev)
 		stmt = planner_hook_prev(parse, query_string,

--- a/src/optimizer/gamma_rewrite_grouping_const.c
+++ b/src/optimizer/gamma_rewrite_grouping_const.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Gamma Data, Inc. <jackey@gammadb.com>
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "postgres.h"
+
+#include "optimizer/gamma_rewrite_grouping_const.h"
+
+/* GUC */
+bool gammadb_rewrite_grouping_const = true;
+
+Query *
+gamma_rewrite_grouping_const(Query *parse)
+{
+	ListCell *lcg;
+	ListCell *lct;
+
+	List *new_group_clause = NULL;
+
+	if (!gammadb_rewrite_grouping_const)
+		return parse;
+
+	if (parse == NULL)
+		return NULL;
+
+	if (parse->groupClause == NULL)
+		return parse;
+
+	foreach (lcg, parse->groupClause)
+	{
+		bool is_const = false;
+		SortGroupClause *sgc = (SortGroupClause *) lfirst(lcg);
+
+		foreach (lct, parse->targetList)
+		{
+			TargetEntry *te = (TargetEntry *) lfirst(lct);
+
+			if (sgc->tleSortGroupRef == te->ressortgroupref)
+			{
+				if (IsA(te->expr, Const))
+					is_const = true;
+
+			}	
+		}
+
+		if (!is_const)
+			new_group_clause = lappend(new_group_clause, sgc);
+	}
+
+	parse->groupClause = new_group_clause;
+
+	return parse;
+}

--- a/test/expected/clickbench_agg_spill.out
+++ b/test/expected/clickbench_agg_spill.out
@@ -1085,19 +1085,17 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: 1, url
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: url
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  
@@ -1111,7 +1109,7 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
         1 | https://produkty%2Fpulove.ru/kiroverlanet.ru/otdam-soulmjj/628965/detail.aspx?Forum.cofe.ru&pvid=163789569-geniya_1538 |  62
         1 | https://produkty/full&qset=159508&s_yers                                                                               |  60
         1 | https://produkty%2Fproduct_id                                                                                          |  50
-        1 | https://produkty/placetti-club/songs/search                                                                            |  43
+        1 | https://produkty%2Fpulove.ru/moscow                                                                                    |  43
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
@@ -2167,23 +2165,21 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: (1), url
+               Group Key: url
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: 1, url
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: url
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  

--- a/test/expected/clickbench_col.out
+++ b/test/expected/clickbench_col.out
@@ -1083,19 +1083,17 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: 1, url
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: url
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  
@@ -1109,7 +1107,7 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
         1 | https://produkty%2Fpulove.ru/kiroverlanet.ru/otdam-soulmjj/628965/detail.aspx?Forum.cofe.ru&pvid=163789569-geniya_1538 |  62
         1 | https://produkty/full&qset=159508&s_yers                                                                               |  60
         1 | https://produkty%2Fproduct_id                                                                                          |  50
-        1 | https://produkty/placetti-club/songs/search                                                                            |  43
+        1 | https://produkty%2Fpulove.ru/moscow                                                                                    |  43
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
@@ -2165,23 +2163,21 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: (1), url
+               Group Key: url
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: 1, url
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: url
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  

--- a/test/expected/clickbench_row.out
+++ b/test/expected/clickbench_row.out
@@ -832,16 +832,16 @@ EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG
 SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits WHERE SearchPhrase <> '' GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
        watchid       |  clientip   | c | sum |          avg          
 ---------------------+-------------+---+-----+-----------------------
+ 8369463583395906354 |  1395825730 | 1 |   0 | 1368.0000000000000000
+ 9151335645112603744 |   847745795 | 1 |   0 | 1638.0000000000000000
+ 5432430776287317993 |  1252089865 | 1 |   1 | 1638.0000000000000000
+ 5792507967286782182 |  1101999299 | 1 |   0 | 2038.0000000000000000
+ 8599202260727970287 | -1857888644 | 1 |   1 | 1368.0000000000000000
  5788394618888602532 |  1944363507 | 1 |   0 | 1828.0000000000000000
+ 6641365122658984572 |    96790945 | 1 |   1 | 1917.0000000000000000
  7838461643255590302 |   915688002 | 1 |   1 |  582.0000000000000000
  8107832680158884727 | -1991775594 | 1 |   1 | 1638.0000000000000000
- 7539370279408310014 |  1655548433 | 1 |   0 | 1638.0000000000000000
- 7375579512685512563 |  1952286433 | 1 |   0 | 1828.0000000000000000
- 8536527937548941165 |  1735595921 | 1 |   1 | 1638.0000000000000000
- 6591337964597835315 |  2089190631 | 1 |   0 | 1828.0000000000000000
- 9014555688819975520 |  1293267909 | 1 |   0 |  253.0000000000000000
- 7676311040847005907 |  2095489375 | 1 |   1 |  661.0000000000000000
- 9151335645112603744 |   847745795 | 1 |   0 | 1638.0000000000000000
+ 6494863097791065214 | -1426977644 | 1 |   1 | 2038.0000000000000000
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
@@ -901,19 +901,17 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: 1, url
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: url
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  
@@ -927,7 +925,7 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
         1 | https://produkty%2Fpulove.ru/kiroverlanet.ru/otdam-soulmjj/628965/detail.aspx?Forum.cofe.ru&pvid=163789569-geniya_1538 |  62
         1 | https://produkty/full&qset=159508&s_yers                                                                               |  60
         1 | https://produkty%2Fproduct_id                                                                                          |  50
-        1 | https://produkty/placetti-club/songs/search                                                                            |  43
+        1 | https://produkty%2Fpulove.ru/moscow                                                                                    |  43
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
@@ -1584,12 +1582,12 @@ SELECT UserID, extract(minute FROM EventTime) AS m, SearchPhrase, COUNT(*) FROM 
 ----------------------+----+--------------+-------
  -7918574344944952583 | 26 |              |    24
  -9154375582268094750 |  1 |              |    20
+ -8455721461950319637 | 21 |              |    16
  -7725127544842036118 | 21 |              |    16
  -8284294157038592779 | 11 |              |    16
- -8455721461950319637 | 21 |              |    16
+ -7018910098174567459 | 57 |              |    14
  -7018910098174567459 | 56 |              |    14
  -7904263253391067902 | 34 |              |    14
- -7018910098174567459 | 57 |              |    14
  -7918574344944952583 |  9 |              |    14
  -9158995094684353950 | 12 |              |    14
 (10 rows)
@@ -1780,23 +1778,25 @@ SELECT SearchPhrase FROM hits WHERE SearchPhrase <> '' ORDER BY EventTime, Searc
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT CounterID, AVG(length(URL)) AS l, COUNT(*) AS c FROM hits WHERE URL <> '' GROUP BY CounterID HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (avg(length(url))) DESC
-         ->  Finalize HashAggregate
+         ->  Finalize GroupAggregate
                Group Key: counterid
                Filter: (count(*) > 100000)
-               ->  Gather
-                     Workers Planned: 7
-                     ->  Custom Scan (gamma_vec_agg)
-                           ->  Partial HashAggregate
-                                 Group Key: counterid
-                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                       ->  Parallel Seq Scan on hits
-                                             Filter: (url OPERATOR(pg_catalog.<>) ''::text)
-(14 rows)
+               ->  Sort
+                     Sort Key: counterid
+                     ->  Gather
+                           Workers Planned: 7
+                           ->  Custom Scan (gamma_vec_agg)
+                                 ->  Partial HashAggregate
+                                       Group Key: counterid
+                                       ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                             ->  Parallel Seq Scan on hits
+                                                   Filter: (url OPERATOR(pg_catalog.<>) ''::text)
+(16 rows)
 
 SELECT CounterID, AVG(length(URL)) AS l, COUNT(*) AS c FROM hits WHERE URL <> '' GROUP BY CounterID HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
  counterid | l | c 
@@ -1866,16 +1866,16 @@ EXPLAIN (COSTS OFF) SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefres
 SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, ClientIP ORDER BY c DESC LIMIT 10;
  searchengineid |  clientip   | c  | sum |          avg          
 ----------------+-------------+----+-----+-----------------------
-             13 |  -673500741 | 20 |  12 | 1638.0000000000000000
               2 |  1735595921 | 20 |   9 | 1638.0000000000000000
+             13 |  -673500741 | 20 |  12 | 1638.0000000000000000
               2 |  -125068408 | 14 |   7 | 1638.0000000000000000
               2 |   743072690 | 12 |   6 | 1368.0000000000000000
               2 |  1140309473 | 12 |   6 | 1638.0000000000000000
               2 | -1555581670 | 12 |   6 | 1638.0000000000000000
               2 | -1300828471 | 10 |   5 | 1396.0000000000000000
               2 |  -181568119 | 10 |   5 | 1996.0000000000000000
+              2 |  1799458087 | 10 |   5 | 1304.0000000000000000
               2 |  1943715871 | 10 |   5 | 1638.0000000000000000
-              2 |  1515936442 | 10 |   5 | 1917.0000000000000000
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits WHERE SearchPhrase <> '' GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
@@ -1900,8 +1900,8 @@ SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FR
  7321312914605605148 | 1558751110 | 1 |   1 | 1996.0000000000000000
  6316522711047084694 | 1863281725 | 1 |   0 | 1368.0000000000000000
  4978746709785681706 |  914180760 | 1 |   1 | 1087.0000000000000000
- 8878638630742086443 | 1160440842 | 1 |   0 | 1638.0000000000000000
  7302370717697016849 | 2050242653 | 1 |   0 | 1638.0000000000000000
+ 8878638630742086443 | 1160440842 | 1 |   0 | 1638.0000000000000000
  7242385807033236675 | 1452202120 | 1 |   0 | 1917.0000000000000000
  6812614815043917687 |  118754044 | 1 |   0 | 1638.0000000000000000
  6919960172226572368 | 2139306194 | 1 |   1 | 1638.0000000000000000
@@ -1927,7 +1927,7 @@ EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG
 SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
        watchid       |  clientip   | c | sum |          avg           
 ---------------------+-------------+---+-----+------------------------
- 7748237181201732285 |  1997103307 | 1 |   0 |  1638.0000000000000000
+ 6285320879265209885 |  1327608256 | 1 |   0 |  1368.0000000000000000
  5206346422301499756 | -1216690514 | 1 |   0 | 0.00000000000000000000
  6426257563931096930 |  2069778861 | 1 |   0 |  1087.0000000000000000
  4893108677938900633 |  1735595921 | 1 |   1 |  1638.0000000000000000
@@ -1936,7 +1936,7 @@ SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FR
  6103859743937398143 |  1088271979 | 1 |   0 |  1368.0000000000000000
  5143451110840006257 |  2139306194 | 1 |   0 |  1638.0000000000000000
  5737380807278362037 |  1714527409 | 1 |   0 |  2428.0000000000000000
- 6285320879265209885 |  1327608256 | 1 |   0 |  1368.0000000000000000
+ 7748237181201732285 |  1997103307 | 1 |   0 |  1638.0000000000000000
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
@@ -1972,23 +1972,21 @@ SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: (1), url
+               Group Key: url
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: 1, url
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: url
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
  ?column? |                                                          url                                                           |  c  
@@ -2032,8 +2030,8 @@ SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hi
  1735595921 | 1735595920 | 1735595919 | 1735595918 | 131
  2107723744 | 2107723743 | 2107723742 | 2107723741 | 126
  1852934819 | 1852934818 | 1852934817 | 1852934816 | 123
- 1943715871 | 1943715870 | 1943715869 | 1943715868 | 112
   934770972 |  934770971 |  934770970 |  934770969 | 112
+ 1943715871 | 1943715870 | 1943715869 | 1943715868 | 112
  1140309473 | 1140309472 | 1140309471 | 1140309470 | 110
  1593446890 | 1593446889 | 1593446888 | 1593446887 | 104
  1262902180 | 1262902179 | 1262902178 | 1262902177 | 102
@@ -2167,23 +2165,22 @@ SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS PageViews FROM hits WH
 (0 rows)
 
 EXPLAIN (COSTS OFF) SELECT DATE_TRUNC('minute', EventTime) AS M, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-14' AND EventDate <= '2013-07-15' AND IsRefresh = 0 AND DontCountHits = 0 GROUP BY DATE_TRUNC('minute', EventTime) ORDER BY DATE_TRUNC('minute', EventTime) LIMIT 10 OFFSET 1000;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                  QUERY PLAN                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, eventtime))
-         ->  Gather Merge
-               Workers Planned: 7
-               ->  Custom Scan (gamma_vec_devector)
-                     ->  Custom Scan (gamma_vec_sort)
-                           ->  Sort
-                                 Sort Key: (date_trunc('minute'::text, eventtime)) USING <
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-                                                         Filter: ((eventdate OPERATOR(pg_catalog.>=) '07-14-2013'::date) AND (eventdate OPERATOR(pg_catalog.<=) '07-15-2013'::date) AND (counterid OPERATOR(pg_catalog.=) 62) AND (isrefresh OPERATOR(pg_catalog.=) 0) AND (dontcounthits OPERATOR(pg_catalog.=) 0))
-(14 rows)
+         Group Key: (vtimestamp_trunc('minute'::text, (date_trunc('minute'::text, eventtime))))
+         ->  Sort
+               Sort Key: (vtimestamp_trunc('minute'::text, (date_trunc('minute'::text, eventtime))))
+               ->  Gather
+                     Workers Planned: 7
+                     ->  Custom Scan (gamma_vec_devector)
+                           ->  Custom Scan (gamma_vec_result)
+                                 ->  Result
+                                       ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                             ->  Parallel Seq Scan on hits
+                                                   Filter: ((eventdate OPERATOR(pg_catalog.>=) '07-14-2013'::date) AND (eventdate OPERATOR(pg_catalog.<=) '07-15-2013'::date) AND (counterid OPERATOR(pg_catalog.=) 62) AND (isrefresh OPERATOR(pg_catalog.=) 0) AND (dontcounthits OPERATOR(pg_catalog.=) 0))
+(13 rows)
 
 SELECT DATE_TRUNC('minute', EventTime) AS M, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-14' AND EventDate <= '2013-07-15' AND IsRefresh = 0 AND DontCountHits = 0 GROUP BY DATE_TRUNC('minute', EventTime) ORDER BY DATE_TRUNC('minute', EventTime) LIMIT 10 OFFSET 1000;
  m | pageviews 


### PR DESCRIPTION
For example:
```
    SELECT 1, URL, COUNT(*) AS c FROM hits
                     GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
```
=>
```
    SELECT 1, URL, COUNT(*) AS c FROM hits
                     GROUP BY URL ORDER BY c DESC LIMIT 10;
```