### PR TITLE
[OPTIMIZER] simplify grouping clauses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ OBJS += src/optimizer/gamma_planner.o \
 		src/optimizer/gamma_upper_paths.o \
 		src/optimizer/gamma_vec_checker.o \
 		src/optimizer/gamma_vec_converter.o \
-		src/optimizer/gamma_rewrite_grouping_const.o
+		src/optimizer/gamma_rewrite_grouping_const.o \
+		src/optimizer/gamma_rewrite_simplify_grouping.o
 
 #src/utils
 OBJS += src/utils/utils.o \

--- a/include/optimizer/gamma_rewrite_simplify_grouping.h
+++ b/include/optimizer/gamma_rewrite_simplify_grouping.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Gamma Data, Inc. <jackey@gammadb.com>
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GAMMA_REWRITE_SIMPLIFY_GROUPING_H
+#define GAMMA_REWRITE_SIMPLIFY_GROUPING_H
+
+#include "postgres.h"
+
+#include "nodes/parsenodes.h"
+#include "nodes/pathnodes.h"
+
+extern Query * gamma_rewrite_simplify_grouping(Query *parse);
+
+#endif /* GAMMA_REWRITE_SIMPLIFY_GROUPING_H */

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -59,6 +59,7 @@ extern double				gammadb_stats_analyze_tuple_factor;
 extern int					gammadb_cv_compress_method;
 
 extern bool					gammadb_rewrite_grouping_const;
+extern bool					gammadb_rewrite_simplify_grouping;
 
 void _PG_init(void);
 
@@ -152,6 +153,14 @@ gamma_guc_init(void)
 							 "Remove const in Grouping Clause.",
 							 NULL,
 							 &gammadb_rewrite_grouping_const,
+							 true,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
+	DefineCustomBoolVariable("gammadb_rewrite_simplify_grouping",
+							 "Simplify Grouping Clause.",
+							 NULL,
+							 &gammadb_rewrite_simplify_grouping,
 							 true,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE,

--- a/src/optimizer/gamma_planner.c
+++ b/src/optimizer/gamma_planner.c
@@ -26,6 +26,7 @@
 #include "optimizer/gamma_converter.h"
 #include "optimizer/gamma_paths.h"
 #include "optimizer/gamma_rewrite_grouping_const.h"
+#include "optimizer/gamma_rewrite_simplify_grouping.h"
 
 
 bool enable_gammadb = false;
@@ -67,6 +68,7 @@ gamma_vec_planner(Query	*parse,
 
 	/* rewrite */
 	parse = gamma_rewrite_grouping_const(parse);
+	parse = gamma_rewrite_simplify_grouping(parse);
 
 	if (planner_hook_prev)
 		stmt = planner_hook_prev(parse, query_string,

--- a/src/optimizer/gamma_rewrite_simplify_grouping.c
+++ b/src/optimizer/gamma_rewrite_simplify_grouping.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2024 Gamma Data, Inc. <jackey@gammadb.com>
+ *
+ * This program is free software: you can use, redistribute, and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3
+ * or later ("AGPL"), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "postgres.h"
+
+#include "nodes/makefuncs.h"
+#include "optimizer/optimizer.h"
+#include "parser/parse_clause.h"
+#include "utils/lsyscache.h"
+#include "nodes/nodeFuncs.h"
+
+#include "optimizer/gamma_rewrite_simplify_grouping.h"
+
+/* GUC */
+bool gammadb_rewrite_simplify_grouping = true;
+
+static Node * gamma_check_can_simplify(Node *expr);
+static bool gamma_check_can_simplify_walker(Node *node, void *ctx);
+static TargetEntry * gamma_find_tle_by_node(Node *node, List *tlist);
+static bool gamma_find_sgc_by_ref(int32 ref, List *sgclist);
+
+
+Query *
+gamma_rewrite_simplify_grouping(Query *parse)
+{
+	ListCell *lcg;
+
+	List *new_group_clause = NULL;
+	List *new_target_list = (List *)copyObject(parse->targetList);
+
+	if (!gammadb_rewrite_simplify_grouping)
+		return parse;
+
+	if (parse == NULL)
+		return NULL;
+
+	if (parse->groupClause == NULL)
+		return parse;
+
+	if (parse->groupingSets != NULL)
+		return parse;
+
+	foreach (lcg, parse->groupClause)
+	{
+		SortGroupClause *sgc = (SortGroupClause *) lfirst(lcg);
+		TargetEntry *gte = get_sortgroupclause_tle(sgc, parse->targetList);
+		Var *var;
+		TargetEntry *tte;
+
+		if (IsA(gte->expr, Var))
+		{
+			new_group_clause = lappend(new_group_clause, sgc);
+			continue;
+		}
+
+		var = (Var *) gamma_check_can_simplify((Node *)gte->expr);
+
+		if (var == NULL)
+		{
+			new_group_clause = lappend(new_group_clause, sgc);
+			continue;
+		}
+
+		tte = gamma_find_tle_by_node((Node *)var, new_target_list);
+
+		if (tte == NULL)
+		{
+			TargetEntry *nte = makeTargetEntry((Expr *)var,
+												list_length(new_target_list) + 1,
+												NULL, true);
+			assignSortGroupRef(nte, new_target_list);
+			sgc->tleSortGroupRef = nte->ressortgroupref;
+
+			new_target_list = lappend(new_target_list, nte);
+			new_group_clause = lappend(new_group_clause, sgc);
+			continue;
+		}
+		else
+		{
+			if (tte->ressortgroupref == 0)
+			{
+				assignSortGroupRef(tte, new_target_list);
+				sgc->tleSortGroupRef = tte->ressortgroupref;
+				new_group_clause = lappend(new_group_clause, sgc);
+			}
+			else
+			{
+				if (gamma_find_sgc_by_ref(tte->ressortgroupref, new_group_clause))
+				{
+					/* useless sgc */
+					continue;
+				}
+
+				sgc->tleSortGroupRef = tte->ressortgroupref;
+				new_group_clause = lappend(new_group_clause, sgc);
+			}
+		}
+	}
+
+	parse->targetList = new_target_list;
+	parse->groupClause = new_group_clause;
+
+	return parse;
+}
+
+/* check target entry */
+typedef struct GammaCanSimplifyContext
+{
+	Var *var;
+	bool pass;
+} GammaCanSimplifyContext;
+
+static Node *
+gamma_check_can_simplify(Node *expr)
+{
+	GammaCanSimplifyContext context;
+	context.var = NULL;
+	context.pass = true;
+
+	gamma_check_can_simplify_walker(expr, &context);
+
+	if (context.pass)
+		return (Node *)context.var;
+	else
+		return NULL;
+}
+
+static bool
+gamma_check_can_simplify_walker(Node *node, void *ctx)
+{
+	GammaCanSimplifyContext *context = (GammaCanSimplifyContext *) ctx;
+
+	if (!context->pass)
+		return false;
+
+	if (IsA(node, OpExpr))
+	{
+		OpExpr *op_expr = (OpExpr *) node;
+		char *op = get_opname(op_expr->opno);
+		if (!strstr("+-*/%", op))
+		{
+			context->pass = false;
+			return false;
+		}
+	}
+	else if (IsA(node, Var))
+	{
+		if (context->var != NULL)
+			context->pass = false;
+
+		context->var = (Var *) node;
+	}
+	else if (IsA(node, Const) || IsA(node, RelabelType))
+	{
+		/* do nothing */
+	}
+	else
+	{
+		context->pass = false;
+		return false;
+	}
+
+	return expression_tree_walker(node, gamma_check_can_simplify_walker,
+									(void *)context);
+}
+
+static TargetEntry *
+gamma_find_tle_by_node(Node *node, List *tlist)
+{
+	ListCell *lct;
+
+	foreach (lct, tlist)
+	{
+		TargetEntry *te = (TargetEntry *) lfirst(lct);
+
+		if (equal((const void *)node, (const void *)te->expr))
+		{
+			return te;
+		}	
+	}
+
+	return NULL;
+}
+
+static bool
+gamma_find_sgc_by_ref(int32 ref, List *sgclist)
+{
+	ListCell *lcg;
+
+	foreach (lcg, sgclist)
+	{
+		SortGroupClause *sgc = (SortGroupClause *) lfirst(lcg);
+
+		if (sgc->tleSortGroupRef == ref)
+		{
+			return true;
+		}
+	}
+
+	return false;
+
+}

--- a/test/expected/clickbench_agg_spill.out
+++ b/test/expected/clickbench_agg_spill.out
@@ -1113,19 +1113,17 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: clientip
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  
@@ -2197,23 +2195,21 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
+               Group Key: clientip
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: clientip
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  

--- a/test/expected/clickbench_col.out
+++ b/test/expected/clickbench_col.out
@@ -1111,19 +1111,17 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: clientip
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  
@@ -2195,23 +2193,21 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
+               Group Key: clientip
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: clientip
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  

--- a/test/expected/clickbench_row.out
+++ b/test/expected/clickbench_row.out
@@ -929,19 +929,17 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Custom Scan (gamma_vec_agg)
                ->  HashAggregate
-                     Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                     ->  Custom Scan (gamma_vec_result)
-                           ->  Result
-                                 ->  Custom Scan (gamma_vec_tablescan)
-                                       ->  Seq Scan on hits
-(10 rows)
+                     Group Key: clientip
+                     ->  Custom Scan (gamma_vec_tablescan)
+                           ->  Seq Scan on hits
+(8 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  
@@ -1582,12 +1580,12 @@ SELECT UserID, extract(minute FROM EventTime) AS m, SearchPhrase, COUNT(*) FROM 
 ----------------------+----+--------------+-------
  -7918574344944952583 | 26 |              |    24
  -9154375582268094750 |  1 |              |    20
- -8455721461950319637 | 21 |              |    16
  -7725127544842036118 | 21 |              |    16
  -8284294157038592779 | 11 |              |    16
- -7018910098174567459 | 57 |              |    14
+ -8455721461950319637 | 21 |              |    16
  -7018910098174567459 | 56 |              |    14
  -7904263253391067902 | 34 |              |    14
+ -7018910098174567459 | 57 |              |    14
  -7918574344944952583 |  9 |              |    14
  -9158995094684353950 | 12 |              |    14
 (10 rows)
@@ -1866,16 +1864,16 @@ EXPLAIN (COSTS OFF) SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefres
 SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, ClientIP ORDER BY c DESC LIMIT 10;
  searchengineid |  clientip   | c  | sum |          avg          
 ----------------+-------------+----+-----+-----------------------
-              2 |  1735595921 | 20 |   9 | 1638.0000000000000000
              13 |  -673500741 | 20 |  12 | 1638.0000000000000000
+              2 |  1735595921 | 20 |   9 | 1638.0000000000000000
               2 |  -125068408 | 14 |   7 | 1638.0000000000000000
-              2 |   743072690 | 12 |   6 | 1368.0000000000000000
-              2 |  1140309473 | 12 |   6 | 1638.0000000000000000
               2 | -1555581670 | 12 |   6 | 1638.0000000000000000
-              2 | -1300828471 | 10 |   5 | 1396.0000000000000000
-              2 |  -181568119 | 10 |   5 | 1996.0000000000000000
-              2 |  1799458087 | 10 |   5 | 1304.0000000000000000
+              2 |  1140309473 | 12 |   6 | 1638.0000000000000000
+              2 |   743072690 | 12 |   6 | 1368.0000000000000000
               2 |  1943715871 | 10 |   5 | 1638.0000000000000000
+              2 |  -181568119 | 10 |   5 | 1996.0000000000000000
+              2 | -1300828471 | 10 |   5 | 1396.0000000000000000
+              2 |  1449805590 | 10 |   6 | 1638.0000000000000000
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits WHERE SearchPhrase <> '' GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
@@ -1927,7 +1925,7 @@ EXPLAIN (COSTS OFF) SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG
 SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM hits GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10;
        watchid       |  clientip   | c | sum |          avg           
 ---------------------+-------------+---+-----+------------------------
- 6285320879265209885 |  1327608256 | 1 |   0 |  1368.0000000000000000
+ 7748237181201732285 |  1997103307 | 1 |   0 |  1638.0000000000000000
  5206346422301499756 | -1216690514 | 1 |   0 | 0.00000000000000000000
  6426257563931096930 |  2069778861 | 1 |   0 |  1087.0000000000000000
  4893108677938900633 |  1735595921 | 1 |   1 |  1638.0000000000000000
@@ -1936,7 +1934,7 @@ SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FR
  6103859743937398143 |  1088271979 | 1 |   0 |  1368.0000000000000000
  5143451110840006257 |  2139306194 | 1 |   0 |  1638.0000000000000000
  5737380807278362037 |  1714527409 | 1 |   0 |  2428.0000000000000000
- 7748237181201732285 |  1997103307 | 1 |   0 |  1638.0000000000000000
+ 6285320879265209885 |  1327608256 | 1 |   0 |  1368.0000000000000000
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
@@ -2004,23 +2002,21 @@ SELECT 1, URL, COUNT(*) AS c FROM hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 (10 rows)
 
 EXPLAIN (COSTS OFF) SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (count(*)) DESC
          ->  Finalize HashAggregate
-               Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
+               Group Key: clientip
                ->  Gather
                      Workers Planned: 7
                      ->  Custom Scan (gamma_vec_agg)
                            ->  Partial HashAggregate
-                                 Group Key: clientip, ((clientip - 1)), ((clientip - 2)), ((clientip - 3))
-                                 ->  Custom Scan (gamma_vec_result)
-                                       ->  Result
-                                             ->  Parallel Custom Scan (gamma_vec_tablescan)
-                                                   ->  Parallel Seq Scan on hits
-(14 rows)
+                                 Group Key: clientip
+                                 ->  Parallel Custom Scan (gamma_vec_tablescan)
+                                       ->  Parallel Seq Scan on hits
+(12 rows)
 
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
   clientip  |  ?column?  |  ?column?  |  ?column?  |  c  
@@ -2030,8 +2026,8 @@ SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hi
  1735595921 | 1735595920 | 1735595919 | 1735595918 | 131
  2107723744 | 2107723743 | 2107723742 | 2107723741 | 126
  1852934819 | 1852934818 | 1852934817 | 1852934816 | 123
-  934770972 |  934770971 |  934770970 |  934770969 | 112
  1943715871 | 1943715870 | 1943715869 | 1943715868 | 112
+  934770972 |  934770971 |  934770970 |  934770969 | 112
  1140309473 | 1140309472 | 1140309471 | 1140309470 | 110
  1593446890 | 1593446889 | 1593446888 | 1593446887 | 104
  1262902180 | 1262902179 | 1262902178 | 1262902177 | 102


### PR DESCRIPTION
For example:
```
SELECT ClientIP+1, ClientIP+2, COUNT(*) AS c FROM hits GROUP BY ClientIP+1, ClientIP+2; 
```
=>
```
SELECT ClientIP+1, ClientIP+2, COUNT(*) AS c FROM hits GROUP BY ClientIP;
```