### PR TITLE
[OPTIMIZER] sorting quals based on selectivity

### DIFF
--- a/src/storage/buffer/gamma_toc.c
+++ b/src/storage/buffer/gamma_toc.c
@@ -218,7 +218,7 @@ gamma_toc_alloc(gamma_toc *toc, Size nbytes)
 			remain_bytes + nbytes < remain_bytes)
 		{
 			result = gamma_toc_invalid((gamma_toc *)vtoc, nbytes);
-			if (result == NULL)
+			if (result != NULL)
 				break;
 				
 			if (gamma_toc_merge((gamma_toc *)vtoc, nbytes))


### PR DESCRIPTION
When create_scan_plan, the quals will be sorted according to the cost. However, because the costs of quals are all default costs, the costs of most quals are the same, so the order will not change much. We add a sorting based on selectivity here, which will rank the qual with low selectivity to the front. Even if we sort based on cost later, under the same cost, the qual with low selectivity will be ranked first.
